### PR TITLE
Fix URL validation regex

### DIFF
--- a/app-racket-stories/validation.rkt
+++ b/app-racket-stories/validation.rkt
@@ -26,7 +26,7 @@
 
 (define (validate-url url)
   (define feedback "Enter an url that starts with http:// or https://")
-  (match (regexp-match #rx"http[s]?://.+" url) ; too permissive?
+  (match (regexp-match #rx"^http[s]?://.+" url) ; too permissive?
     [#f (validation url #t #t feedback)]
     [_  (validation url #t #f "")]))
 


### PR DESCRIPTION
The current regex for validating a submission link only checks whether the URL _contains_ `http[s]?://.+` rather than whether the URL _begins_ with `http[s]?://.+`. To correct that, we simply add a caret character at the beginning of the regex like so: 

`^http[s]?://.+`

Which is exactly what I've done in this Pull Request.

There are other factors that would prevent an actual XSS injection, but these can also be worked around. For a more thorough exploration of the problem, see Issue https://github.com/soegaard/racket-stories/issues/14